### PR TITLE
Fixed "bad exception" when trying to close unsaved files

### DIFF
--- a/DiscordRPforVSPackage.cs
+++ b/DiscordRPforVSPackage.cs
@@ -193,10 +193,10 @@
             }
         }
 
-        protected override Int32 QueryClose(out Boolean canClose)
+        protected override void Dispose(Boolean disposing)
         {
-            this.Dispose();
-            return base.QueryClose(out canClose);
+            Dispose();
+            base.Dispose(disposing);
         }
 
         public void Dispose() => this.Discord.Dispose();


### PR DESCRIPTION
The extension used to dispose in [`Package.QueryClose`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.package.queryclose?view=visualstudiosdk-2019), which is called whenever there's an attempt to close VS. That was causing the Discord client to be disposed in scenarios where closing Visual Studio was interrupted by other events or extensions (like when closing unsaved files). The disposing code was moved to an override for [`Package.Dispose`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.package.dispose?view=visualstudiosdk-2019).